### PR TITLE
Spinball: increase menu timeout check

### DIFF
--- a/SEGAMasterSplitter.asl
+++ b/SEGAMasterSplitter.asl
@@ -418,7 +418,7 @@ update
                      vars.lastmenuoption == 1
                  )
                  &&
-                 menutimeout > 2 &&
+                 menutimeout > 10 &&
                 
                 vars.watchers["trigger"].Old == 3 &&
                 vars.watchers["trigger"].Current == 2 ) {


### PR DESCRIPTION
Prevents Demo from starting splitter, but may cause people who start late to not start the timer