### PR TITLE
Reinitialise vars on reset

### DIFF
--- a/SEGAMasterSplitter.asl
+++ b/SEGAMasterSplitter.asl
@@ -10,6 +10,7 @@ state("SEGAGameRoom") {}
 state("SEGAGenesisClassics") {}
 state("blastem") {}
 state("Sonic3AIR") {}
+
 init
 {
     vars.gamename = timer.Run.GameName;
@@ -2483,6 +2484,11 @@ reset
         current.reset = false;
         return true;
     }
+}
+
+onReset
+{
+    vars.reInitialise();
 }
 
 split


### PR DESCRIPTION
Prevents double splitting (on fade and on level change) after a prior completed run in Sonic 3D Blast

Since this only seems to affect Sonic 3D Blast it would also be possible to just reset vars.bossdown, however as long as there's no noticeable lag from doing this we can afford future proofing this imo.